### PR TITLE
Update to Openwall 1.1.3 C source

### DIFF
--- a/Crypto/BCrypt.hs
+++ b/Crypto/BCrypt.hs
@@ -58,7 +58,9 @@ data HashingPolicy = HashingPolicy {
     --
     --       * Cost 12: 0.72 passwords / second
     preferredHashCost :: Int,
-    -- | Preferred algorithm - the preferred hash algorithm. $2y$ for bcrypt.
+    -- | Preferred algorithm - the preferred hash algorithm.
+    --   The default is $2y$ (compatible with other Openwall-based
+    --   libraries). The most up-to-date version is $2b$.
     preferredHashAlgorithm :: BS.ByteString
   }
 

--- a/bcrypt.cabal
+++ b/bcrypt.cabal
@@ -10,10 +10,10 @@ Maintainer: andrew@amxl.com
 Category: Data, Cryptography
 Stability: experimental
 description: Haskell bindings to the bcrypt password hash.
-
+             .
              Unlike other bindings already in existence, this package is designed to allow users to work directly with password hash strings that include information about the hashing algorithm, strength, and salt. This approach allows hashed passwords to be stored in a single field that can also be used by non-Haskell applications, and makes it easy to implement a policy of updating passwords hashed to an old policy next time the plaintext password is available.
-
-             The OpenWall version of the C source for bcrypt (modified so it will build on all platforms without any assembler code) is included in this package.
+             .
+             Version 1.1.3 of the OpenWall C source for bcrypt is included in this package (<http://www.openwall.com/crypt/>). The only modification is that the flag which enables the use of assembler has been disabled.
 synopsis: Haskell bindings to the bcrypt password hash
 extra-source-files: csrc/crypt_blowfish.h csrc/crypt_gensalt.h csrc/crypt.h csrc/ow-crypt.h
 
@@ -22,7 +22,7 @@ Library
   include-dirs: csrc
   c-sources: csrc/crypt_blowfish.c csrc/crypt_blowfish_wrapper.c csrc/crypt_gensalt.c
   build-depends: bytestring >= 0.9,
-                 entropy < 0.3,
+                 entropy < 0.4,
                  base >= 3 && < 5
 
 source-repository head

--- a/csrc/crypt_blowfish.c
+++ b/csrc/crypt_blowfish.c
@@ -7,11 +7,11 @@
  * and crypt(3) interfaces added, but optimizations specific to password
  * cracking removed.
  *
- * Written by Solar Designer <solar at openwall.com> in 1998-2011.
+ * Written by Solar Designer <solar at openwall.com> in 1998-2014.
  * No copyright is claimed, and the software is hereby placed in the public
  * domain.  In case this attempt to disclaim copyright and place the software
  * in the public domain is deemed null and void, then the software is
- * Copyright (c) 1998-2011 Solar Designer and it is hereby released to the
+ * Copyright (c) 1998-2014 Solar Designer and it is hereby released to the
  * general public under the following terms:
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,12 +27,12 @@
  * you place this code and any modifications you make under a license
  * of your choice.
  *
- * This implementation is mostly compatible with OpenBSD's bcrypt.c (prefix
- * "$2a$") by Niels Provos <provos at citi.umich.edu>, and uses some of his
- * ideas.  The password hashing algorithm was designed by David Mazieres
- * <dm at lcs.mit.edu>.  For more information on the level of compatibility,
- * prefer refer to the comments in BF_set_key() below and to the included
- * crypt(3) man page.
+ * This implementation is fully compatible with OpenBSD's bcrypt.c for prefix
+ * "$2b$", originally by Niels Provos <provos at citi.umich.edu>, and it uses
+ * some of his ideas.  The password hashing algorithm was designed by David
+ * Mazieres <dm at lcs.mit.edu>.  For information on the level of
+ * compatibility for bcrypt hash prefixes other than "$2b$", please refer to
+ * the comments in BF_set_key() below and to the included crypt(3) man page.
  *
  * There's a paper on the algorithm that explains its design decisions:
  *
@@ -54,7 +54,7 @@
 #include "crypt_blowfish.h"
 
 #ifdef __i386__
-#define BF_ASM				0
+#define BF_ASM				1
 #define BF_SCALE			1
 #elif defined(__x86_64__) || defined(__alpha__) || defined(__hppa__)
 #define BF_ASM				0
@@ -578,6 +578,7 @@ static void BF_set_key(const char *key, BF_key expanded, BF_key initial,
  * Valid combinations of settings are:
  *
  * Prefix "$2a$": bug = 0, safety = 0x10000
+ * Prefix "$2b$": bug = 0, safety = 0
  * Prefix "$2x$": bug = 1, safety = 0
  * Prefix "$2y$": bug = 0, safety = 0
  */
@@ -641,6 +642,10 @@ static void BF_set_key(const char *key, BF_key expanded, BF_key initial,
 	initial[0] ^= sign;
 }
 
+static const unsigned char flags_by_subtype[26] =
+	{2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 0};
+
 static char *BF_crypt(const char *key, const char *setting,
 	char *output, int size,
 	BF_word min)
@@ -648,9 +653,6 @@ static char *BF_crypt(const char *key, const char *setting,
 #if BF_ASM
 	extern void _BF_body_r(BF_ctx *ctx);
 #endif
-	static const unsigned char flags_by_subtype[26] =
-		{2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 0};
 	struct {
 		BF_ctx ctx;
 		BF_key expanded_key;
@@ -816,9 +818,10 @@ char *_crypt_blowfish_rn(const char *key, const char *setting,
 {
 	const char *test_key = "8b \xd0\xc1\xd2\xcf\xcc\xd8";
 	const char *test_setting = "$2a$00$abcdefghijklmnopqrstuu";
-	static const char * const test_hash[2] =
-		{"VUrPmXD6q/nVSSp7pNDhCR9071IfIRe\0\x55", /* $2x$ */
-		"i1D709vfamulimlGcq0qq3UvuUasvEa\0\x55"}; /* $2a$, $2y$ */
+	static const char * const test_hashes[2] =
+		{"i1D709vfamulimlGcq0qq3UvuUasvEa\0\x55", /* 'a', 'b', 'y' */
+		"VUrPmXD6q/nVSSp7pNDhCR9071IfIRe\0\x55"}; /* 'x' */
+	const char *test_hash = test_hashes[0];
 	char *retval;
 	const char *p;
 	int save_errno, ok;
@@ -840,17 +843,19 @@ char *_crypt_blowfish_rn(const char *key, const char *setting,
  * detected by the self-test.
  */
 	memcpy(buf.s, test_setting, sizeof(buf.s));
-	if (retval)
+	if (retval) {
+		unsigned int flags = flags_by_subtype[
+		    (unsigned int)(unsigned char)setting[2] - 'a'];
+		test_hash = test_hashes[flags & 1];
 		buf.s[2] = setting[2];
+	}
 	memset(buf.o, 0x55, sizeof(buf.o));
 	buf.o[sizeof(buf.o) - 1] = 0;
 	p = BF_crypt(test_key, buf.s, buf.o, sizeof(buf.o) - (1 + 1), 1);
 
 	ok = (p == buf.o &&
 	    !memcmp(p, buf.s, 7 + 22) &&
-	    !memcmp(p + (7 + 22),
-	    test_hash[(unsigned int)(unsigned char)buf.s[2] & 1],
-	    31 + 1 + 1 + 1));
+	    !memcmp(p + (7 + 22), test_hash, 31 + 1 + 1 + 1));
 
 	{
 		const char *k = "\xff\xa3" "34" "\xff\xff\xff\xa3" "345";
@@ -879,7 +884,7 @@ char *_crypt_gensalt_blowfish_rn(const char *prefix, unsigned long count,
 	if (size < 16 || output_size < 7 + 22 + 1 ||
 	    (count && (count < 4 || count > 31)) ||
 	    prefix[0] != '$' || prefix[1] != '2' ||
-	    (prefix[2] != 'a' && prefix[2] != 'y')) {
+	    (prefix[2] != 'a' && prefix[2] != 'b' && prefix[2] != 'y')) {
 		if (output_size > 0) output[0] = '\0';
 		__set_errno((output_size < 7 + 22 + 1) ? ERANGE : EINVAL);
 		return NULL;

--- a/csrc/crypt_blowfish_wrapper.c
+++ b/csrc/crypt_blowfish_wrapper.c
@@ -1,9 +1,9 @@
 /*
- * Written by Solar Designer <solar at openwall.com> in 2000-2011.
+ * Written by Solar Designer <solar at openwall.com> in 2000-2014.
  * No copyright is claimed, and the software is hereby placed in the public
  * domain.  In case this attempt to disclaim copyright and place the software
  * in the public domain is deemed null and void, then the software is
- * Copyright (c) 2000-2011 Solar Designer and it is hereby released to the
+ * Copyright (c) 2000-2014 Solar Designer and it is hereby released to the
  * general public under the following terms:
  *
  * Redistribution and use in source and binary forms, with or without
@@ -210,7 +210,8 @@ char *__crypt_gensalt_rn(const char *prefix, unsigned long count,
 		return NULL;
 	}
 
-	if (!strncmp(prefix, "$2a$", 4) || !strncmp(prefix, "$2y$", 4))
+	if (!strncmp(prefix, "$2a$", 4) || !strncmp(prefix, "$2b$", 4) ||
+	    !strncmp(prefix, "$2y$", 4))
 		use = _crypt_gensalt_blowfish_rn;
 	else
 	if (!strncmp(prefix, "$1$", 3))
@@ -293,9 +294,13 @@ static const char *tests[][3] = {
 		"\xff\xff\xa3"},
 	{"$2a$05$/OK.fbVrR/bpIqNJ5ianF.nqd1wy.pTMdcvrRWxyiGL2eMz.2a85.",
 		"\xff\xff\xa3"},
+	{"$2b$05$/OK.fbVrR/bpIqNJ5ianF.CE5elHaaO4EbggVDjb8P19RukzXSM3e",
+		"\xff\xff\xa3"},
 	{"$2y$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq",
 		"\xa3"},
 	{"$2a$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq",
+		"\xa3"},
+	{"$2b$05$/OK.fbVrR/bpIqNJ5ianF.Sa7shbm4.OzKpvFnX1pQLmQW96oUlCq",
 		"\xa3"},
 	{"$2x$05$/OK.fbVrR/bpIqNJ5ianF.o./n25XVfn6oAPaUvHe.Csk4zRfsYPi",
 		"1\xa3" "345"},
@@ -347,6 +352,7 @@ static const char *tests[][3] = {
 		""},
 	{"*0", "", "$2a$03$CCCCCCCCCCCCCCCCCCCCC."},
 	{"*0", "", "$2a$32$CCCCCCCCCCCCCCCCCCCCC."},
+	{"*0", "", "$2c$05$CCCCCCCCCCCCCCCCCCCCC."},
 	{"*0", "", "$2z$05$CCCCCCCCCCCCCCCCCCCCC."},
 	{"*0", "", "$2`$05$CCCCCCCCCCCCCCCCCCCCC."},
 	{"*0", "", "$2{$05$CCCCCCCCCCCCCCCCCCCCC."},


### PR DESCRIPTION
This adds support for the $2b$ prefix which will be used in future
versions of OpenBSD. See

http://marc.info/?l=openbsd-misc&m=139320023202696&q=raw

or

http://undeadly.org/cgi?action=article&sid=20140224132743

for the background on why it was introduced.

This commit
- Adds the updated C source.
- Updates the project description to clarify the version used and which
  modifications have been made to the openwall source, and provides a
  link to the original source website.
- Raises the upper bound on the 'entropy' dependency to avoid cabal
  problems.

In future, the default algorithm should probably be switched to "$2b$
since this will allow for maximum compatibility between systems, but it’s
probably best to wait until other libraries also have support.
