### PR TITLE
Bumps entropy dependency upperbound to < 0.0.4

### DIFF
--- a/bcrypt.cabal
+++ b/bcrypt.cabal
@@ -22,8 +22,8 @@ Library
   include-dirs: csrc
   c-sources: csrc/crypt_blowfish.c csrc/crypt_blowfish_wrapper.c csrc/crypt_gensalt.c
   build-depends: bytestring >= 0.9,
-                 entropy < 0.3,
-                 base >= 3 && < 5
+                 entropy    <  0.4,
+                 base       >= 3       && < 5
 
 source-repository head
   type: git


### PR DESCRIPTION
Based on what I can can see, there's no reason [entropy 0.3.*](https://github.com/TomMD/entropy/compare/1a8bf9ea79cf5b34b21779ae88d3bbc9a60544ad...master) should break anything here, though I don't know anything about Xen. If there's specific testing you'd like me to help with, I'm willing to help. It would be convenient to have this dependency raised. Apologies for the lame pull request.
