### PR TITLE
Avoid orphan instances and define defaults

### DIFF
--- a/bcrypt.cabal
+++ b/bcrypt.cabal
@@ -24,10 +24,11 @@ Library
   exposed-modules: Crypto.BCrypt
   include-dirs: csrc
   c-sources: csrc/crypt_blowfish.c csrc/crypt_blowfish_wrapper.c csrc/crypt_gensalt.c
-  build-depends: bytestring >= 0.9,
-                 entropy < 0.4,
-                 base >= 3 && < 5,
-                 memory >= 0.9 && < 1.0
+  build-depends: base >= 3 && < 5
+               , bytestring >= 0.9
+               , data-default >= 0.6.0
+               , entropy < 0.4
+               , memory >= 0.9 && < 1.0
 
 source-repository head
   type: git


### PR DESCRIPTION
It's considered a good practice to define at least some necessary typeclass instances for the exported datatypes. Also providing defaults is a good and common way of enabling users to override part of the structure(see `Default`). I made the changes in the way to not break backwards compatibility, if these instances were defined in the user codebase, GHC will issue a warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/a1kmm/hs-bcrypt/10)
<!-- Reviewable:end -->
