### PR TITLE
Fix Windows build break

### DIFF
--- a/csrc/crypt_blowfish_wrapper.c
+++ b/csrc/crypt_blowfish_wrapper.c
@@ -37,6 +37,10 @@
 #define CRYPT_OUTPUT_SIZE		(7 + 22 + 31 + 1)
 #define CRYPT_GENSALT_OUTPUT_SIZE	(7 + 22 + 1)
 
+#if defined(_WIN64) && _WIN64
+#define strdup _strdup
+#endif
+
 #if defined(__GLIBC__) && defined(_LIBC)
 #define __SKIP_GNU
 #endif


### PR DESCRIPTION
strdup is not defined on Windows.  #define _strdup to strdup to work
around this.

This is a common Windows build problem, and many other C packages use the
same fix.
